### PR TITLE
Tweak the display of Studio's version

### DIFF
--- a/tasks/package.mjs
+++ b/tasks/package.mjs
@@ -107,7 +107,7 @@ async function main() {
     path.join(studioDir, 'package.json')
   ).version
   const modified = original.replaceAll(
-    '__RW_STUDIO_VERISON_REPLACE_ME__',
+    '__RW_STUDIO_VERSION__',
     'v' + studioVersion
   )
   fs.writeFileSync(indexHTMLPath, modified)

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <script>
-      window.RW_STUDIO_VERSION = "__RW_STUDIO_VERISON_REPLACE_ME__"
+      <!-- The string here is replaced during packaging of Studio -->
+      window.RW_STUDIO_VERSION = "__RW_STUDIO_VERSION__"
     </script>
   </head>
 

--- a/web/src/layouts/SidebarLayout/SidebarLayout.tsx
+++ b/web/src/layouts/SidebarLayout/SidebarLayout.tsx
@@ -220,10 +220,10 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                       <Flex
                         flexDirection="col"
                         justifyContent="start"
-                        alignItems="center"
+                        alignItems="start"
                       >
                         <Title className="pl-4">RedwoodJS Studio</Title>
-                        <Subtitle className="pl-4">
+                        <Subtitle className="-mt-1 pl-6 text-sm">
                           {window.RW_STUDIO_VERSION}
                         </Subtitle>
                       </Flex>
@@ -326,10 +326,12 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
               <Flex
                 flexDirection="col"
                 justifyContent="start"
-                alignItems="center"
+                alignItems="start"
               >
                 <Title className="pl-4">RedwoodJS Studio</Title>
-                <Subtitle className="pl-4">{window.RW_STUDIO_VERSION}</Subtitle>
+                <Subtitle className="-mt-1 pl-6 text-sm">
+                  {window.RW_STUDIO_VERSION}
+                </Subtitle>
               </Flex>
             </div>
             <nav className="flex flex-1 flex-col">

--- a/web/types/ambient.d.ts
+++ b/web/types/ambient.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  RW_STUDIO_VERSION: string
+}


### PR DESCRIPTION
* Fixed the spelling of VERSION (was VERISON)
* Removed _REPLACE_ME__ as I thought that sounded like some kind of TODO-comment.
   * Added comment to the file instead to explain what's going on
* Used declaration merging to tell TS about `window.RS_STUDIO_VERSION` to get rid of red squiggles 
* Tweaked the visuals a bit on how we display the version

Original, without version:
![image](https://github.com/redwoodjs/studio/assets/30793/1ca8349c-df49-4fcb-939f-81cda935ee44)

Current:
![image](https://github.com/redwoodjs/studio/assets/30793/2e08b1d4-4644-43e1-87f0-49c0f45df000)

This PR:
![image](https://github.com/redwoodjs/studio/assets/30793/09edc04b-3ad5-45ef-9ad6-871b6f247071)
 