### PR TITLE
rw-studio-impersonation-cookie

### DIFF
--- a/web/src/components/RedwoodGraphiQL/RedwoodGraphiQL.tsx
+++ b/web/src/components/RedwoodGraphiQL/RedwoodGraphiQL.tsx
@@ -102,6 +102,8 @@ export function RedwoodGraphiQL(
   const urlLoader = useMemo(() => new UrlLoader(), [])
 
   const fetcher: Fetcher = useMemo(() => {
+    const headers = props.additionalHeaders || {}
+
     const executor = urlLoader.getExecutorAsync(endpoint, {
       subscriptionsProtocol: SubscriptionProtocol.SSE,
       credentials: 'same-origin',
@@ -109,7 +111,7 @@ export function RedwoodGraphiQL(
       directiveIsRepeatable: true,
       fetch: window.fetch,
       ...props,
-      headers: props.additionalHeaders || {},
+      headers,
     })
 
     return function fetcher(graphQLParams: FetcherParams, opts?: FetcherOpts) {
@@ -117,6 +119,9 @@ export function RedwoodGraphiQL(
         parse(graphQLParams.query),
         graphQLParams.operationName ?? undefined
       )
+
+      headers['rw-studio-impersonation-cookie'] =
+        opts?.headers?.cookie || opts?.headers?.Cookie
 
       return executor({
         document,


### PR DESCRIPTION
Sending the cookie as a header lets us grab it synchronously in RW. The body needs to be parsed async when switching to Web Requests.

See https://github.com/redwoodjs/redwood/issues/9801