### PR TITLE
feat: Adds loading, failure/error, and empty states to Line Charts

### DIFF
--- a/web/src/components/ApiPerformanceCell/ApiPerformanceCell.tsx
+++ b/web/src/components/ApiPerformanceCell/ApiPerformanceCell.tsx
@@ -6,9 +6,9 @@ import type {
 
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+import ChartCard from 'src/components/Charts/ChartCard'
 import ChartEmptyState from 'src/components/Charts/ChartEmptyState'
 import ChartFailureState from 'src/components/Charts/ChartFailureState'
-import ChartHeading from 'src/components/Charts/ChartHeading'
 import ChartLoadingState from 'src/components/Charts/ChartLoadingState'
 import PerformanceLineChart from 'src/components/Charts/LineCharts/PerformanceLineChart'
 import { ApiPerformanceIcon } from 'src/icons/Icons'
@@ -34,14 +34,36 @@ export const QUERY = gql`
   }
 `
 
-export const Loading = () => <ChartLoadingState />
+export const Loading = () => (
+  <ChartCard
+    caption="API Performance"
+    icon={ApiPerformanceIcon}
+    tooltip="API Performance"
+  >
+    <ChartLoadingState />
+  </ChartCard>
+)
 
-export const Empty = () => <ChartEmptyState />
+export const Empty = () => (
+  <ChartCard
+    caption="API Performance"
+    icon={ApiPerformanceIcon}
+    tooltip="API Performance"
+  >
+    <ChartEmptyState />
+  </ChartCard>
+)
 
 export const Failure = ({
   error,
 }: CellFailureProps<GetApiPerformanceQueryVariables>) => (
-  <ChartFailureState message={error.message} />
+  <ChartCard
+    caption="API Performance"
+    icon={ApiPerformanceIcon}
+    tooltip="API Performance"
+  >
+    <ChartFailureState message={error.message} />
+  </ChartCard>
 )
 
 export const Success = ({
@@ -51,13 +73,12 @@ export const Success = ({
   GetApiPerformanceQueryVariables
 >) => {
   return (
-    <Card>
-      <ChartHeading
-        caption="API Performance"
-        icon={ApiPerformanceIcon}
-        tooltip="API Performance"
-      />
+    <ChartCard
+      caption="API Performance"
+      icon={ApiPerformanceIcon}
+      tooltip="API Performance"
+    >
       <PerformanceLineChart dataPoints={dataPoints} />
-    </Card>
+    </ChartCard>
   )
 }

--- a/web/src/components/Charts/ChartCard.tsx
+++ b/web/src/components/Charts/ChartCard.tsx
@@ -6,7 +6,7 @@ import ChartHeading from './ChartHeading'
 
 interface ChartCardProps {
   caption: string
-  icon: React.ComponentType<any> // Adjust the type according to the actual type of DatabasePerformanceIcon
+  icon: React.ElementType
   tooltip?: string
   children: ReactNode
 }

--- a/web/src/components/Charts/ChartCard.tsx
+++ b/web/src/components/Charts/ChartCard.tsx
@@ -1,0 +1,25 @@
+import React, { ReactNode } from 'react'
+
+import { Card } from '@tremor/react'
+
+import ChartHeading from './ChartHeading'
+
+interface ChartCardProps {
+  caption: string
+  icon: React.ComponentType<any> // Adjust the type according to the actual type of DatabasePerformanceIcon
+  tooltip?: string
+  children: ReactNode
+}
+
+const ChartCard: React.FC<ChartCardProps> = ({
+  caption,
+  icon,
+  tooltip,
+  children,
+}) => (
+  <Card>
+    <ChartHeading caption={caption} icon={icon} tooltip={tooltip || caption} />
+    {children}
+  </Card>
+)
+export default ChartCard

--- a/web/src/components/Charts/ChartEmptyState.tsx
+++ b/web/src/components/Charts/ChartEmptyState.tsx
@@ -6,10 +6,6 @@ const ChartEmptyState = () => (
     data={[]}
     index="ago"
     categories={[]}
-    colors={[]}
-    yAxisWidth={40}
-    connectNulls={true}
-    allowDecimals={true}
     noDataText="No recent data to display"
   />
 )

--- a/web/src/components/Charts/ChartEmptyState.tsx
+++ b/web/src/components/Charts/ChartEmptyState.tsx
@@ -1,5 +1,17 @@
-import { Title } from '@tremor/react'
+import { LineChart } from '@tremor/react'
 
-const ChartEmptyState = () => <Title>Empty</Title>
+const ChartEmptyState = () => (
+  <LineChart
+    className="mt-6"
+    data={[]}
+    index="ago"
+    categories={[]}
+    colors={[]}
+    yAxisWidth={40}
+    connectNulls={true}
+    allowDecimals={true}
+    noDataText="No recent data to display"
+  />
+)
 
 export default ChartEmptyState

--- a/web/src/components/Charts/ChartFailureState.tsx
+++ b/web/src/components/Charts/ChartFailureState.tsx
@@ -6,10 +6,6 @@ const ChartFailureState = ({ message }: { message: string }) => (
     data={[]}
     index="ago"
     categories={[]}
-    colors={[]}
-    yAxisWidth={40}
-    connectNulls={true}
-    allowDecimals={true}
     noDataText={message}
   />
 )

--- a/web/src/components/Charts/ChartFailureState.tsx
+++ b/web/src/components/Charts/ChartFailureState.tsx
@@ -1,7 +1,17 @@
-import { Bold } from '@tremor/react'
+import { LineChart } from '@tremor/react'
 
 const ChartFailureState = ({ message }: { message: string }) => (
-  <Bold color="red">{message}</Bold>
+  <LineChart
+    className="mt-6"
+    data={[]}
+    index="ago"
+    categories={[]}
+    colors={[]}
+    yAxisWidth={40}
+    connectNulls={true}
+    allowDecimals={true}
+    noDataText={message}
+  />
 )
 
 export default ChartFailureState

--- a/web/src/components/Charts/ChartLoadingState.tsx
+++ b/web/src/components/Charts/ChartLoadingState.tsx
@@ -1,9 +1,17 @@
-import { Title } from '@tremor/react'
+import { LineChart } from '@tremor/react'
 
 const ChartLoadingState = ({
   message = 'Loading ...',
 }: {
   message?: string
-}) => <Title>{message}</Title>
+}) => (
+  <LineChart
+    className="mt-6"
+    data={[]}
+    index="ago"
+    categories={[]}
+    noDataText={message}
+  />
+)
 
 export default ChartLoadingState

--- a/web/src/components/DatabasePerformanceCell/DatabasePerformanceCell.tsx
+++ b/web/src/components/DatabasePerformanceCell/DatabasePerformanceCell.tsx
@@ -6,9 +6,9 @@ import type {
 
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+import ChartCard from 'src/components/Charts/ChartCard'
 import ChartEmptyState from 'src/components/Charts/ChartEmptyState'
 import ChartFailureState from 'src/components/Charts/ChartFailureState'
-import ChartHeading from 'src/components/Charts/ChartHeading'
 import ChartLoadingState from 'src/components/Charts/ChartLoadingState'
 import PerformanceLineChart from 'src/components/Charts/LineCharts/PerformanceLineChart'
 import { DatabasePerformanceIcon } from 'src/icons/Icons'
@@ -34,14 +34,36 @@ export const QUERY = gql`
   }
 `
 
-export const Loading = () => <ChartLoadingState />
+export const Loading = () => (
+  <ChartCard
+    caption="Database Performance"
+    icon={DatabasePerformanceIcon}
+    tooltip="Database Performance"
+  >
+    <ChartLoadingState />
+  </ChartCard>
+)
 
-export const Empty = () => <ChartEmptyState />
+export const Empty = () => (
+  <ChartCard
+    caption="Database Performance"
+    icon={DatabasePerformanceIcon}
+    tooltip="Database Performance"
+  >
+    <ChartEmptyState />
+  </ChartCard>
+)
 
 export const Failure = ({
   error,
 }: CellFailureProps<GetDatabasePerformanceQueryVariables>) => (
-  <ChartFailureState message={error.message} />
+  <ChartCard
+    caption="Database Performance"
+    icon={DatabasePerformanceIcon}
+    tooltip="Database Performance"
+  >
+    <ChartFailureState message={error.message} />
+  </ChartCard>
 )
 
 export const Success = ({
@@ -51,13 +73,12 @@ export const Success = ({
   GetDatabasePerformanceQueryVariables
 >) => {
   return (
-    <Card>
-      <ChartHeading
-        caption="Database Performance"
-        icon={DatabasePerformanceIcon}
-        tooltip="Database Performance"
-      />
+    <ChartCard
+      caption="Database Performance"
+      icon={DatabasePerformanceIcon}
+      tooltip="Database Performance"
+    >
       <PerformanceLineChart dataPoints={dataPoints} />
-    </Card>
+    </ChartCard>
   )
 }

--- a/web/src/components/GraphQLPerformanceCell/GraphQLPerformanceCell.tsx
+++ b/web/src/components/GraphQLPerformanceCell/GraphQLPerformanceCell.tsx
@@ -6,9 +6,9 @@ import type {
 
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+import ChartCard from 'src/components/Charts/ChartCard'
 import ChartEmptyState from 'src/components/Charts/ChartEmptyState'
 import ChartFailureState from 'src/components/Charts/ChartFailureState'
-import ChartHeading from 'src/components/Charts/ChartHeading'
 import ChartLoadingState from 'src/components/Charts/ChartLoadingState'
 import PerformanceLineChart from 'src/components/Charts/LineCharts/PerformanceLineChart'
 import { GraphQLPerformanceIcon } from 'src/icons/Icons'
@@ -34,14 +34,36 @@ export const QUERY = gql`
   }
 `
 
-export const Loading = () => <ChartLoadingState />
+export const Loading = () => (
+  <ChartCard
+    caption="GraphQL Performance"
+    icon={GraphQLPerformanceIcon}
+    tooltip="GraphQL Performance"
+  >
+    <ChartLoadingState />
+  </ChartCard>
+)
 
-export const Empty = () => <ChartEmptyState />
+export const Empty = () => (
+  <ChartCard
+    caption="GraphQL Performance"
+    icon={GraphQLPerformanceIcon}
+    tooltip="GraphQL Performance"
+  >
+    <ChartEmptyState />
+  </ChartCard>
+)
 
 export const Failure = ({
   error,
 }: CellFailureProps<GetGraphQLPerformanceQueryVariables>) => (
-  <ChartFailureState message={error.message} />
+  <ChartCard
+    caption="GraphQL Performance"
+    icon={GraphQLPerformanceIcon}
+    tooltip="GraphQL Performance"
+  >
+    <ChartFailureState message={error.message} />
+  </ChartCard>
 )
 
 export const Success = ({
@@ -51,13 +73,12 @@ export const Success = ({
   GetGraphQLPerformanceQueryVariables
 >) => {
   return (
-    <Card>
-      <ChartHeading
-        caption="GraphQL Performance"
-        icon={GraphQLPerformanceIcon}
-        tooltip="GraphQL Performance"
-      />
+    <ChartCard
+      caption="GraphQL Performance"
+      icon={GraphQLPerformanceIcon}
+      tooltip="GraphQL Performance"
+    >
       <PerformanceLineChart dataPoints={dataPoints} />{' '}
-    </Card>
+    </ChartCard>
   )
 }

--- a/web/src/components/NetworkPerformanceCell/NetworkPerformanceCell.tsx
+++ b/web/src/components/NetworkPerformanceCell/NetworkPerformanceCell.tsx
@@ -6,9 +6,9 @@ import type {
 
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+import ChartCard from 'src/components/Charts/ChartCard'
 import ChartEmptyState from 'src/components/Charts/ChartEmptyState'
 import ChartFailureState from 'src/components/Charts/ChartFailureState'
-import ChartHeading from 'src/components/Charts/ChartHeading'
 import ChartLoadingState from 'src/components/Charts/ChartLoadingState'
 import PerformanceLineChart from 'src/components/Charts/LineCharts/PerformanceLineChart'
 import { NetworkPerformanceIcon } from 'src/icons/Icons'
@@ -34,14 +34,36 @@ export const QUERY = gql`
   }
 `
 
-export const Loading = () => <ChartLoadingState />
+export const Loading = () => (
+  <ChartCard
+    caption="Network Performance"
+    icon={NetworkPerformanceIcon}
+    tooltip="Network Performance"
+  >
+    <ChartLoadingState />
+  </ChartCard>
+)
 
-export const Empty = () => <ChartEmptyState />
+export const Empty = () => (
+  <ChartCard
+    caption="Network Performance"
+    icon={NetworkPerformanceIcon}
+    tooltip="Network Performance"
+  >
+    <ChartEmptyState />
+  </ChartCard>
+)
 
 export const Failure = ({
   error,
 }: CellFailureProps<GetNetworkPerformanceQueryVariables>) => (
-  <ChartFailureState message={error.message} />
+  <ChartCard
+    caption="Network Performance"
+    icon={NetworkPerformanceIcon}
+    tooltip="Network Performance"
+  >
+    <ChartFailureState message={error.message} />
+  </ChartCard>
 )
 
 export const Success = ({
@@ -51,13 +73,12 @@ export const Success = ({
   GetNetworkPerformanceQueryVariables
 >) => {
   return (
-    <Card>
-      <ChartHeading
-        caption="Network Performance"
-        icon={NetworkPerformanceIcon}
-        tooltip="Network Performance"
-      />
+    <ChartCard
+      caption="Network Performance"
+      icon={NetworkPerformanceIcon}
+      tooltip="Network Performance"
+    >
       <PerformanceLineChart dataPoints={dataPoints} />{' '}
-    </Card>
+    </ChartCard>
   )
 }


### PR DESCRIPTION
This PR adds some improved empty, loading, and failure/error state visualization by:

* keeping a chart heading card with icon consistent across all states (including Success with data)
* uses the `noDataText` attribute of the LineChart https://www.tremor.so/docs/visualizations/line-chart to display the message

### Empty

![image](https://github.com/redwoodjs/studio/assets/1051633/a13d2da3-121f-4889-924f-5358a1e1fc8e)

### Failure

![image](https://github.com/redwoodjs/studio/assets/1051633/c2787fef-a589-47dd-afe2-f8284327b68c)


### Loading

![image](https://github.com/redwoodjs/studio/assets/1051633/27a14b9b-5112-49de-a8ee-dcc767ac50b3)


### Success

![image](https://github.com/redwoodjs/studio/assets/1051633/dedca830-6173-4b33-8877-df0ece8353ed)

