### PR TITLE
chore: Removes SSR section from Sidebar

### DIFF
--- a/web/src/layouts/SidebarLayout/SidebarLayout.tsx
+++ b/web/src/layouts/SidebarLayout/SidebarLayout.tsx
@@ -42,6 +42,9 @@ type TNavigationItem = {
   icon: typeof HomeIcon
 }
 
+ // v7 ships with SSR section disabled as Bighorn introduces the feature
+const includeSSR = false
+
 const NavigationItem = ({ item }: { item: TNavigationItem }) => {
   return (
     <div className="flex w-full">
@@ -303,6 +306,7 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                             ))}
                           </ul>
                         </li>
+                        {includeSSR && (
                         <li>
                           <div className="text-xs font-semibold leading-6 text-gray-400">
                             SSR
@@ -315,6 +319,7 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                             ))}
                           </ul>
                         </li>
+                        )}
                         <li className="mb-6 mt-auto">
                           <div className="text-xs font-semibold leading-6 text-gray-400">
                             Development Server
@@ -409,6 +414,7 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                     ))}
                   </ul>
                 </li>
+                {includeSSR && (
                 <li>
                   <div className="text-xs font-semibold leading-6 text-gray-400 dark:text-gray-600">
                     SSR
@@ -421,6 +427,7 @@ const SidebarLayout = ({ children }: SidebarLayoutProps) => {
                     ))}
                   </ul>
                 </li>
+                )}
                 <li className="mb-6 mt-auto">
                   <div className="text-xs font-semibold leading-6 text-gray-400 dark:text-gray-600">
                     Development Server


### PR DESCRIPTION
Per discussion with @Tobbe, as v7 does not yet introduce SSR, this PR removes the OG Tag Preview / SSR option from the Sidebar.

Note: just a UI change. Routes ,pages, and core feature remains.