### PR TITLE
chore: Minor Studio usability and cosmetic tweaks

### DIFF
--- a/__fixtures__/test-project/api/src/opentelemetry.ts
+++ b/__fixtures__/test-project/api/src/opentelemetry.ts
@@ -26,11 +26,12 @@ const resource = Resource.default().merge(
 const studioPort = getConfig().studio.basePort
 const exporter = new OTLPTraceExporter({
   // Update this URL to point to where your OTLP compatible collector is listening
-  // The redwood development studio (`yarn rw exp studio`) can collect your
+  // The redwood development studio (`yarn rw studio`) can collect your
   // telemetry at `http://127.0.0.1:<PORT>/.redwood/functions/otel-trace`
   // (default PORT is 4318)
   url: `http://127.0.0.1:${studioPort}/.redwood/functions/otel-trace`,
-  concurrencyLimit: 128,
+  concurrencyLimit: 256,
+  timeoutMillis: 30000,
 })
 
 // You may wish to switch to BatchSpanProcessor in production as it is the recommended choice for performance reasons

--- a/__fixtures__/test-project/api/src/services/posts/posts.ts
+++ b/__fixtures__/test-project/api/src/services/posts/posts.ts
@@ -7,12 +7,14 @@ import type {
 import { db } from 'src/lib/db'
 
 export const posts: QueryResolvers['posts'] = () => {
+  // { include: { author: true } }
   return db.post.findMany()
 }
 
 export const post: QueryResolvers['post'] = ({ id }) => {
   return db.post.findUnique({
     where: { id },
+    // include: { author: true },
   })
 }
 
@@ -37,6 +39,10 @@ export const deletePost: MutationResolvers['deletePost'] = ({ id }) => {
 
 export const Post: PostRelationResolvers = {
   author: (_obj, { root }) => {
+    // if (root.author) {
+    //   return root.author
+    // }
+
     return db.post.findUnique({ where: { id: root?.id } }).author()
   },
 }

--- a/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.tsx
+++ b/__fixtures__/test-project/web/src/pages/AboutPage/AboutPage.tsx
@@ -1,6 +1,3 @@
-import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
-
 const AboutPage = () => {
   return (
     <p className="font-light">

--- a/api/src/services/statistics/statistics.ts
+++ b/api/src/services/statistics/statistics.ts
@@ -10,7 +10,7 @@ export const spanStatistics: QueryResolvers['spanStatistics'] = async ({
   typeId,
   attributeKey,
   attributeValue,
-  intervalMins = 5,
+  intervalMins = 1,
 }: {
   typeId: string
   attributeKey: string

--- a/api/src/services/statistics/statistics.ts
+++ b/api/src/services/statistics/statistics.ts
@@ -63,7 +63,7 @@ export const spanStatistics: QueryResolvers['spanStatistics'] = async ({
     ROUND(CAST((avgDuration / 1000000000.000) AS REAL), 3) AS avgDurationSec
   FROM
     t2
-  ORDER BY intervalStartedAt DESC`
+  ORDER BY statisticCount DESC, intervalStartedAt DESC`
 }
 
 export const sqlStatementStatistics: QueryResolvers['sqlStatementStatistics'] =
@@ -164,7 +164,7 @@ SELECT
 	ROUND(CAST((avgDuration / 1000000000.000) AS REAL), 3) AS avgDurationSec
 FROM
 	t2
-	order by 2, 1;`
+ORDER BY 1 DESC, 2 DESC;`
   }
 
 export const sqlStatementAttributeStatistics: QueryResolvers['sqlStatementAttributeStatistics'] =

--- a/api/src/util/fsWatching.ts
+++ b/api/src/util/fsWatching.ts
@@ -20,7 +20,7 @@ export async function startWatchers() {
     interval: 500,
   })
 
-  // TODO: We should batch up the changed files so we can make optimisations
+  // TODO: We should batch up the changed files so we can make optimizations
 
   const listenOnEventsForDist = ['ready', 'add', 'change']
   for (let i = 0; i < listenOnEventsForDist.length; i++) {

--- a/redwood.toml
+++ b/redwood.toml
@@ -21,9 +21,10 @@
   open = true
 [notifications]
   versionUpdates = ["canary"]
-
+[generate]
+  tests = false
+  stories = false
 [experimental.serverFile]
 	enabled = true
-
 [experimental.realtime]
 	enabled = true

--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -24,7 +24,8 @@ const Routes = () => {
         <Route path="/mailer/template-preview" page={MailerTemplatePreviewPage} name="mailerTemplatePreview" />
 
         <Route path="/ssr/og-tag-preview" page={OGTagPreviewPage} name="ogTagPreview" />
-        <Route path="/info" page={InfoPage} name="info" />
+        <Route path="/studio/settings" page={InfoPage} name="settings" />
+        <Route path="/studio/about" page={AboutPage} name="about" />
       </Set>
       <Route notfound page={NotFoundPage} />
     </Router>

--- a/web/src/components/GraphQLOperationsCell/GraphQLOperationsCell.tsx
+++ b/web/src/components/GraphQLOperationsCell/GraphQLOperationsCell.tsx
@@ -22,7 +22,7 @@ import StatisticsIntervalTable from '../Statistics/StatisticsIntervalTable'
 export const beforeQuery = (props) => {
   return {
     variables: props,
-    pollInterval: 5000,
+    pollInterval: 2_000,
     fetchPolicy: 'cache-and-network',
   }
 }
@@ -38,7 +38,7 @@ export const QUERY = gql`
       attributeKey
       attributeValue
     }
-    statistics: graphQLOperationStatistics {
+    statistics: graphQLOperationStatistics(intervalMins: 1) {
       intervalStartedAt
       statisticCount
       minDuration
@@ -99,7 +99,7 @@ export const Success = ({
             <Col numColSpanSm={2} numColSpanLg={3}>
               <StatisticsIntervalChart
                 statistics={statistics}
-                interval={'5 Min'}
+                interval={'1 Min'}
               />
             </Col>
             <Col numColSpanSm={2} numColSpanLg={3}>
@@ -108,7 +108,7 @@ export const Success = ({
             <Col numColSpanSm={2} numColSpanLg={3}>
               <StatisticsIntervalTable
                 statistics={statistics}
-                interval={'5 Min'}
+                interval={'1 Min'}
               />
             </Col>
           </Grid>

--- a/web/src/components/GraphQLPerformanceCell/GraphQLPerformanceCell.tsx
+++ b/web/src/components/GraphQLPerformanceCell/GraphQLPerformanceCell.tsx
@@ -15,7 +15,7 @@ import { GraphQLPerformanceIcon } from 'src/icons/Icons'
 export const beforeQuery = (props) => {
   return {
     variables: props,
-    pollInterval: 5000,
+    pollInterval: 2_000,
   }
 }
 

--- a/web/src/components/GraphQLSchemaCell/GraphQLSchemaDiagram.tsx
+++ b/web/src/components/GraphQLSchemaCell/GraphQLSchemaDiagram.tsx
@@ -162,7 +162,7 @@ const LayoutFlow = ({ schema }: { schema: GraphQLSchema }) => {
   return (
     <div className="h-[640px] w-full min-w-[320px]">
       <ReactFlow
-        className="bg-teal-50"
+        className="bg-zinc-50"
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}

--- a/web/src/components/GraphQLStatsCell/GraphQLStatsCell.tsx
+++ b/web/src/components/GraphQLStatsCell/GraphQLStatsCell.tsx
@@ -9,6 +9,13 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import ChartHeading from 'src/components/Charts/ChartHeading'
 import { GraphQLIcon } from 'src/icons/Icons'
 
+export const beforeQuery = (props) => {
+  return {
+    variables: props,
+    pollInterval: 2_000,
+  }
+}
+
 export const QUERY = gql`
   query GraphQLDashboardStatsQuery {
     stats: graphQLOperationAttributeStatistics {

--- a/web/src/components/MailerStatsCell/MailerStatsCell.tsx
+++ b/web/src/components/MailerStatsCell/MailerStatsCell.tsx
@@ -9,6 +9,13 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import ChartHeading from 'src/components/Charts/ChartHeading'
 import { EnvelopeIcon } from 'src/icons/Icons'
 
+export const beforeQuery = (props) => {
+  return {
+    variables: props,
+    pollInterval: 2_000,
+  }
+}
+
 export const QUERY = gql`
   query FindMailCountQuery @live {
     mailAPICount
@@ -41,7 +48,7 @@ export const Success = ({
       name: 'SMTP/Nodemailer',
       value: mailSMTPCount,
     },
-  ]
+  ].sort((a, b) => b.value - a.value)
 
   return (
     <>

--- a/web/src/components/MonitoringStatsCell/MonitoringStatsCell.tsx
+++ b/web/src/components/MonitoringStatsCell/MonitoringStatsCell.tsx
@@ -9,6 +9,13 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import ChartHeading from 'src/components/Charts/ChartHeading'
 import { MonitoringIcon } from 'src/icons/Icons'
 
+export const beforeQuery = (props) => {
+  return {
+    variables: props,
+    pollInterval: 2_000,
+  }
+}
+
 export const QUERY = gql`
   query MonitoringStatsQuery @live {
     otelTraceCount
@@ -39,7 +46,7 @@ export const Success = ({
       name: 'Spans',
       value: otelSpanCount,
     },
-  ]
+  ].sort((a, b) => b.value - a.value)
 
   let avg = 0
 

--- a/web/src/components/SQLStatementsCell/SQLStatementsCell.tsx
+++ b/web/src/components/SQLStatementsCell/SQLStatementsCell.tsx
@@ -22,7 +22,7 @@ import StatisticsIntervalTable from '../Statistics/StatisticsIntervalTable'
 export const beforeQuery = (props) => {
   return {
     variables: props,
-    pollInterval: 5000,
+    pollInterval: 2_000,
     fetchPolicy: 'cache-and-network',
   }
 }
@@ -38,7 +38,7 @@ export const QUERY = gql`
       attributeKey
       attributeValue
     }
-    statistics: sqlStatementStatistics {
+    statistics: sqlStatementStatistics(intervalMins: 1) {
       intervalStartedAt
       statisticCount
       minDuration
@@ -97,7 +97,7 @@ export const Success = ({
             <Col numColSpanSm={2} numColSpanLg={3}>
               <StatisticsIntervalChart
                 statistics={statistics}
-                interval={'5 Min'}
+                interval={'1 Min'}
               />
             </Col>
             <Col numColSpanSm={2} numColSpanLg={3}>
@@ -106,7 +106,7 @@ export const Success = ({
             <Col numColSpanSm={2} numColSpanLg={3}>
               <StatisticsIntervalTable
                 statistics={statistics}
-                interval={'5 Min'}
+                interval={'1 Min'}
               />
             </Col>
           </Grid>

--- a/web/src/components/SQLStatsCell/SQLStatsCell.tsx
+++ b/web/src/components/SQLStatsCell/SQLStatsCell.tsx
@@ -9,6 +9,13 @@ import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 import ChartHeading from 'src/components/Charts/ChartHeading'
 import { DatabaseIcon } from 'src/icons/Icons'
 
+export const beforeQuery = (props) => {
+  return {
+    variables: props,
+    pollInterval: 2_000,
+  }
+}
+
 export const QUERY = gql`
   query SQLDashboardStatsQuery {
     stats: sqlStatementAttributeStatistics {

--- a/web/src/components/SpanMetadata/SpanMetadata.tsx
+++ b/web/src/components/SpanMetadata/SpanMetadata.tsx
@@ -106,13 +106,19 @@ export const SpanMetadata = ({
       <ListItem>
         <span>Started At</span>
         <span>
-          {formatISO(toDate(parseInt(startTimeNano) / 1_000_000_000.0))}
+          {formatISO(toDate(parseInt(startTimeNano) / 1_000_000.0), {
+            format: 'extended',
+            representation: 'complete',
+          })}
         </span>
       </ListItem>
       <ListItem>
         <span>Ended At</span>
         <span>
-          {formatISO(toDate(parseInt(endTimeNano) / 1_000_000_000.0))}
+          {formatISO(toDate(parseInt(endTimeNano) / 1_000_000.0), {
+            format: 'extended',
+            representation: 'complete',
+          })}
         </span>
       </ListItem>
       <ListItem>

--- a/web/src/icons/Icons.ts
+++ b/web/src/icons/Icons.ts
@@ -28,7 +28,7 @@ export {
   InboxIcon,
   EnvelopeIcon,
   EnvelopeIcon as MailerIcon,
-  InformationCircleIcon as InfoIcon,
+  InformationCircleIcon as AboutIcon,
   LinkIcon,
   ListBulletIcon as OperationsIcon,
   MagnifyingGlassCircleIcon as InspectorIcon,
@@ -42,6 +42,9 @@ export {
   VariableIcon,
   ViewColumnsIcon as PlaygroundIcon,
   XMarkIcon as CloseIcon,
+  MagnifyingGlassCircleIcon as SearchIcon,
+  HeartIcon as MadeWithRedwoodIcon,
+  RocketLaunchIcon as MoreIcon,
 } from '@heroicons/react/24/outline'
 
 export { DocumentDuplicateIcon as DocumentDuplicateSolidIcon } from '@heroicons/react/20/solid'

--- a/web/src/layouts/SidebarLayout/NavigationMenu.tsx
+++ b/web/src/layouts/SidebarLayout/NavigationMenu.tsx
@@ -1,4 +1,4 @@
-import { Flex, Subtitle, Title } from '@tremor/react'
+import { Flex, Title } from '@tremor/react'
 
 import { NavLink, routes } from '@redwoodjs/router'
 
@@ -120,10 +120,6 @@ export const NavigationMenu = () => {
         <img className="h-8 w-auto" src="/mark.svg" alt="RedwoodJS" />
         <Flex flexDirection="col" justifyContent="start" alignItems="start">
           <Title className="pl-4">RedwoodJS Studio</Title>
-          {/* The version number is moved up and to the right on purpose */}
-          <Subtitle className="-mt-1 pl-6 text-sm">
-            {window.RW_STUDIO_VERSION}
-          </Subtitle>
         </Flex>
       </div>
       <nav className="flex flex-1 flex-col">

--- a/web/src/layouts/SidebarLayout/NavigationMenu.tsx
+++ b/web/src/layouts/SidebarLayout/NavigationMenu.tsx
@@ -3,11 +3,12 @@ import { Flex, Title } from '@tremor/react'
 import { NavLink, routes } from '@redwoodjs/router'
 
 import {
+  AboutIcon,
   DashboardIcon,
   ErdIcon,
   GraphQLIcon,
   InboxIcon,
-  InfoIcon,
+  SettingsIcon,
   OGTagPreviewIcon,
   OperationsIcon,
   PlaygroundIcon,
@@ -111,7 +112,8 @@ export const NavigationMenu = () => {
   ]
 
   const studioNavigation: TNavigationItem[] = [
-    { name: 'Info', to: routes.info(), icon: InfoIcon },
+    { name: 'Settings', to: routes.settings(), icon: SettingsIcon },
+    { name: 'About', to: routes.about(), icon: AboutIcon },
   ]
 
   return (

--- a/web/src/pages/AboutPage/AboutPage.tsx
+++ b/web/src/pages/AboutPage/AboutPage.tsx
@@ -1,0 +1,139 @@
+import { Icon, Title } from '@tremor/react'
+
+import { routes, Link } from '@redwoodjs/router'
+import { Metadata } from '@redwoodjs/web'
+
+import {
+  DashboardIcon,
+  DatabasePerformanceIcon,
+  GraphQLIcon,
+  MailerIcon,
+  MadeWithRedwoodIcon,
+  MoreIcon,
+  MonitoringIcon,
+  SearchIcon,
+  SettingsIcon,
+} from 'src/icons/Icons'
+
+const features = [
+  {
+    name: 'Dashboard',
+    description:
+      'Your app at a glance. Measure Database, GraphQL, API and Network performance in real-time. Quickly see the most executed SQL and GraphQL Operations.',
+    to: routes.home(),
+    icon: DashboardIcon,
+  },
+  {
+    name: 'Monitoring',
+    description:
+      'Studio is powered by OpenTelemetry sent by your Redwood app. See what traces and spans reveal about the health of your app. Find a problem? Rework and compare the difference to see the improvement.',
+    to: routes.opentelemetryTraces(),
+    icon: MonitoringIcon,
+  },
+  {
+    name: 'GraphQL',
+    description:
+      'Visualize your GraphQL Schema. Measure GraphQL Operations and performance. Easily test out your GraphQL API in a fully-integrated GraphiQL Playground complete with authenticated User Impersonation.',
+    to: routes.graphqlSchema(),
+    icon: GraphQLIcon,
+  },
+  {
+    name: 'Database',
+    description:
+      'Visualize your Prisma database diagram. Explore your data model and relations, Measure SQL Statement performance in detail.',
+    to: routes.databaseSchema(),
+    icon: DatabasePerformanceIcon,
+  },
+  {
+    name: 'Mailer',
+    description:
+      'Intercept emails in development. See what emails are being sent and received. Test out your email templates.',
+    to: routes.mailerInbox(),
+    icon: MailerIcon,
+  },
+  {
+    name: 'Search',
+    description:
+      'Quickly search the RedwoodJS Community, Documentation, and more. Get help to build your app faster. Just Command-K and go!',
+    to: null,
+    icon: SearchIcon,
+  },
+  {
+    name: 'Settings',
+    description:
+      'Customize your Studio. See what features are enabled, and how User Impersonation is configured.',
+    to: routes.settings(),
+    icon: SettingsIcon,
+  },
+  {
+    name: 'Made with Redwood',
+    description:
+      'Studio is built with RedwoodJS. It uses Realtime GraphQL to update data, cells for data fetching, routing for navigation, and more.',
+    to: null,
+    icon: MadeWithRedwoodIcon,
+  },
+  {
+    name: 'And more ...',
+    description:
+      'We have lots of plans for the future. We are always adding new features and improvements. Check out our GitHub to see what we are working on.',
+    to: null,
+    icon: MoreIcon,
+  },
+]
+
+const AboutPage = () => {
+  return (
+    <div className="py-4">
+      <Metadata title="About" description="About Redwood Studio" />
+
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto max-w-2xl lg:text-center">
+          <h2 className="text-tremor-600 text-base font-semibold leading-7 text-tremor-brand dark:text-dark-tremor-brand">
+            About
+          </h2>
+
+          <Title className="font-3xl mt-2 tracking-tight sm:text-4xl">
+            Get to Know Redwood Studio
+          </Title>
+          <p className="mt-6 text-lg leading-8 text-tremor-content dark:text-dark-tremor-content">
+            Studio is your trusty companion for RedwoodJS development. It&apos;s
+            here to make your coding journey smoother by helping you
+            collaborate, visualize, and track your app&apos;s performance.
+            Let&apos;s make coding more enjoyable and informative together!
+          </p>
+        </div>
+        <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-none">
+          <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-16 lg:max-w-none lg:grid-cols-3">
+            {features.map((feature) => (
+              <div key={feature.name} className="flex flex-col">
+                <dt className="flex items-center gap-x-3 text-base font-bold leading-7 text-tremor-brand dark:text-dark-tremor-brand">
+                  <Icon
+                    icon={feature.icon}
+                    className="h-6 w-6"
+                    aria-hidden="true"
+                  />
+                  {feature.name}
+                </dt>
+                <dd className="mt-4 flex flex-auto flex-col text-base leading-7 text-tremor-content dark:text-dark-tremor-content">
+                  <p className="flex-auto">{feature.description}</p>
+                  <p className="mt-6">
+                    {feature.to && (
+                      <Link
+                        to={feature.to}
+                        className="text-sm font-semibold leading-6 text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis"
+                      >
+                        Try it! <span aria-hidden="true">→</span>
+                      </Link>
+                    )}
+                  </p>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AboutPage

--- a/web/src/pages/AboutPage/AboutPage.tsx
+++ b/web/src/pages/AboutPage/AboutPage.tsx
@@ -19,42 +19,42 @@ const features = [
   {
     name: 'Dashboard',
     description:
-      'Your app at a glance. Measure Database, GraphQL, API and Network performance in real-time. Quickly see the most executed SQL and GraphQL Operations.',
+      'A quick overview of your app. Monitor Database, GraphQL, API, and Network performance in real-time. Instantly view the most executed SQL and GraphQL Operations.',
     to: routes.home(),
     icon: DashboardIcon,
   },
   {
     name: 'Monitoring',
     description:
-      'Studio is powered by OpenTelemetry sent by your Redwood app. See what traces and spans reveal about the health of your app. Find a problem? Rework and compare the difference to see the improvement.',
+      "Studio leverages OpenTelemetry data sent from your Redwood app. Observe what traces and spans indicate about your app's health. Found a problem? Make adjustments and then compare the difference to assess the improvement.",
     to: routes.opentelemetryTraces(),
     icon: MonitoringIcon,
   },
   {
     name: 'GraphQL',
     description:
-      'Visualize your GraphQL Schema. Measure GraphQL Operations and performance. Easily test out your GraphQL API in a fully-integrated GraphiQL Playground complete with authenticated User Impersonation.',
+      'Explore your GraphQL API with ease. Visualize your GraphQL Schema. Evaluate GraphQL Operations and performance. Test your GraphQL API effortlessly in a fully-integrated GraphiQL Playground. Supports authenticated User Impersonation.',
     to: routes.graphqlSchema(),
     icon: GraphQLIcon,
   },
   {
     name: 'Database',
     description:
-      'Visualize your Prisma database diagram. Explore your data model and relations, Measure SQL Statement performance in detail.',
+      'Enhance your understanding and usage of your Database and SQL. Visualize your Prisma database diagram. Explore your data model and its relations. Evaluate the performance of SQL statements in detail.',
     to: routes.databaseSchema(),
     icon: DatabasePerformanceIcon,
   },
   {
     name: 'Mailer',
     description:
-      'Intercept emails in development. See what emails are being sent and received. Test out your email templates.',
+      'Redwood Studio is closely integrated with Redwood Mailer. Intercept emails during development. Monitor the emails being sent and received. Test and preview your email templates.',
     to: routes.mailerInbox(),
     icon: MailerIcon,
   },
   {
     name: 'Search',
     description:
-      'Quickly search the RedwoodJS Community, Documentation, and more. Get help to build your app faster. Just Command-K and go!',
+      "We're always here to help. Quickly search the RedwoodJS Community, Documentation, and more. Get help to build your app faster. Just Command-K and go!",
     to: null,
     icon: SearchIcon,
   },
@@ -68,14 +68,14 @@ const features = [
   {
     name: 'Made with Redwood',
     description:
-      'Studio is built with RedwoodJS. It uses Realtime GraphQL to update data, cells for data fetching, routing for navigation, and more.',
+      'Studio is built with RedwoodJS. It uses Realtime GraphQL to update data, cells for data fetching, authentication, routing for navigation, and more.',
     to: null,
     icon: MadeWithRedwoodIcon,
   },
   {
     name: 'And more ...',
     description:
-      'We have lots of plans for the future. We are always adding new features and improvements. Check out our GitHub to see what we are working on.',
+      "We're super excited about the future versions of Studio. Based on your valuable feedback and needs, we're planning to refine and expand Studio's features even further.  Check out our GitHub to see what we are working on.",
     to: null,
     icon: MoreIcon,
   },

--- a/web/src/pages/InfoPage/InfoPage.tsx
+++ b/web/src/pages/InfoPage/InfoPage.tsx
@@ -5,12 +5,12 @@ import InfoCell from 'src/components/InfoCell'
 const InfoPage = () => {
   return (
     <>
-      <Metadata title="Info" description="Info page" />
+      <Metadata title="Settings" description="Settings page" />
       <h3 className="text-tremor-title font-bold text-tremor-content-strong dark:text-dark-tremor-content-strong">
-        Info
+        Settings
       </h3>
       <p className="mt-2 text-tremor-default leading-6 text-tremor-content dark:text-dark-tremor-content">
-        Information about Studio
+        Studio configuration and settings
       </p>
       <InfoCell />
     </>

--- a/web/src/pages/MailerInboxPage/MailerInboxPage.tsx
+++ b/web/src/pages/MailerInboxPage/MailerInboxPage.tsx
@@ -229,7 +229,7 @@ const MailerInboxPage = () => {
                 </TabPanel>
                 <TabPanel>
                   <Text className="pt-4 text-center">
-                    Visualisation of API mail is not yet supported
+                    Visualization of API mail is not yet supported
                   </Text>
                 </TabPanel>
               </TabPanels>

--- a/web/src/pages/OpenTelemetrySpansPage/OpenTelemetrySpansPage.tsx
+++ b/web/src/pages/OpenTelemetrySpansPage/OpenTelemetrySpansPage.tsx
@@ -7,6 +7,8 @@ import {
   Flex,
   Button,
   Divider,
+  Select,
+  SelectItem,
   TextInput,
 } from '@tremor/react'
 import {
@@ -176,13 +178,16 @@ const OpenTelemetrySpansPage = () => {
                 setNameFilter(e.currentTarget.value)
               }}
             />
-            <TextInput
-              placeholder="Type"
-              value={typeFilter}
-              onChange={(e) => {
-                setTypeFilter(e.currentTarget.value)
-              }}
-            />
+
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectItem value="">ALL</SelectItem>
+              <SelectItem value="GRAPHQL">GRAPHQL</SelectItem>
+              <SelectItem value="SQL">SQL</SelectItem>
+              <SelectItem value="PRISMA">PRISMA</SelectItem>
+              <SelectItem value="REDWOOD FUNCTION">FUNCTION</SelectItem>
+              <SelectItem value="REDWOOD SERVICE">SERVICE</SelectItem>
+              <SelectItem value="GENERIC">GENERIC</SelectItem>
+            </Select>
           </Flex>
         </Card>
         {spans.length === 0 && (


### PR DESCRIPTION
While running through some demo trials for Town Hall, I noticed a few minor UX, usability issues that I wanted to address:

* move version from Nav to Info page
* make sure dashboard stats widgets poll to refresh
* make diagram react flow background consistent color
* correct span stats date time display (not 1970)
* add select list for span filtering
* better sort metrics and stats
* remove some British English
* updates telemetry concurrency and timeout
* prep test project posts service to eager load authors
* adds About page to use in TH walkthrough
* 1 min granularity for stats demos better (will change to a select list of various intervals later)