### PR TITLE
fix: Fixes starting Studio from a project path that includes spaces

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -49,20 +49,24 @@ export async function serve(
 
   // Execute prisma migrate
   // 'rw build' should have generated the prisma client already
+  const prismaSchemaPath = path
+    .join(__dirname, '../db/schema.prisma')
+    .replaceAll(' ', '\\ ')
+
   logger.info('Migrating local Prisma database')
   await execa.command(
-    `npx prisma migrate deploy --schema ${path.join(
-      __dirname,
-      '../db/schema.prisma'
-    )}`,
+    `npx prisma migrate deploy --schema ${prismaSchemaPath}`,
     {
       stdio: 'inherit',
     }
   )
 
   // Execute the prisma seed
+  const prismaSeedPath = path
+    .join(__dirname, 'lib', 'seed.js')
+    .replaceAll(' ', '\\ ')
   logger.info('Running any seeding of the Prisma database')
-  await execa.command(`node ${path.join(__dirname, 'lib', 'seed.js')}`, {
+  await execa.command(`node ${prismaSeedPath}`, {
     stdio: 'inherit',
   })
 


### PR DESCRIPTION
Fixes #37 

The paths to the Prisma schema and seed script were not properly escaped using `exec.command`.

Since we use v 5.1.1 (which is still isn't elm like v8.0.1) escaping is not automatically done and the documentation states:

```
execa.command(command, options?)

Same as [execa()](https://github.com/redwoodjs/studio/compare/dt-run-with-spaces-in-project-dir?expand=1#execafile-arguments-options) except both file and arguments are specified in a single command string. For example, execa('echo', ['unicorns']) is the same as execa.command('echo unicorns').

If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if command is not a constant but a variable, for example with __dirname or process.cwd(). Except for spaces, no escaping/quoting is needed.
```

The PR explicitly escapes the paths.