### PR TITLE
chore: Temporary update the concurrent limit in the fixture

### DIFF
--- a/__fixtures__/test-project/api/src/opentelemetry.ts
+++ b/__fixtures__/test-project/api/src/opentelemetry.ts
@@ -30,7 +30,7 @@ const exporter = new OTLPTraceExporter({
   // telemetry at `http://127.0.0.1:<PORT>/.redwood/functions/otel-trace`
   // (default PORT is 4318)
   url: `http://127.0.0.1:${studioPort}/.redwood/functions/otel-trace`,
-  concurrencyLimit: 256,
+  concurrencyLimit: 1024,
   timeoutMillis: 30000,
 })
 


### PR DESCRIPTION
We have to revisit the opentelemetry setup on the framework side of things to do things like use the batch span processor in order to truly fix this issue. For now lets further bump up the limit to keep studio moving forward right now.