### PR TITLE
fix: GraphiQL endpoint configuration

### DIFF
--- a/api/src/util/graphqlProxy.ts
+++ b/api/src/util/graphqlProxy.ts
@@ -13,12 +13,13 @@ export async function graphqlProxy(
   done: HookHandlerDoneFunction
 ) {
   const webConfig = getUserProjectConfig().web
+  const webHost = webConfig.host ?? 'localhost'
   const graphqlEndpoint =
     webConfig.apiGraphQLUrl ??
-    `http://${webConfig.host}:${webConfig.port}${webConfig.apiUrl}/graphql`
+    `http://${webHost}:${webConfig.port}${webConfig.apiUrl}/graphql`
 
   fastify.register(httpProxy, {
-    upstream: `http://${webConfig.host}:${webConfig.port}`,
+    upstream: `http://${webHost}:${webConfig.port}`,
     prefix: '/proxies/graphql',
     // Strip the initial scheme://host:port from the graphqlEndpoint
     rewritePrefix: '/' + graphqlEndpoint.split('/').slice(3).join('/'),


### PR DESCRIPTION
We relied on `web.host` from the user's TOML. This however can be undefined and in this case, we were making requests to `http://undefined:8910/...`. When this happened the graphiql playground would fail to make any requests to the users graphql API. 

Instead, now we default this to `localhost` when the value is undefined. 