### PR TITLE
fix: generate client at runtime

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -12,10 +12,7 @@ import { coerceRootPath, redwoodFastifyWeb } from '@redwoodjs/fastify-web'
 
 import { logger } from 'src/lib/logger'
 
-import { startConnectionWatching } from './util/connectionWatching'
-import { startWatchers } from './util/fsWatching'
 import { graphqlProxy } from './util/graphqlProxy'
-import { handleMail } from './util/mail'
 import {
   getStudioConfig,
   getStudioStatePath,
@@ -47,12 +44,17 @@ export async function serve(
     path.join(studioStateDirectory, 'prisma.sqlite')
   )}?connection_limit=1`
 
-  // Execute prisma migrate
-  // 'rw build' should have generated the prisma client already
   const prismaSchemaPath = path
     .join(__dirname, '../db/schema.prisma')
     .replaceAll(' ', '\\ ')
 
+  // Generate the Prisma client, this is done at runtime as it is platform/architecture specific
+  logger.info('Generating Prisma client')
+  await execa.command(`npx prisma generate --schema ${prismaSchemaPath}`, {
+    stdio: 'inherit',
+  })
+
+  // Execute prisma migrate
   logger.info('Migrating local Prisma database')
   await execa.command(
     `npx prisma migrate deploy --schema ${prismaSchemaPath}`,
@@ -101,12 +103,17 @@ export async function serve(
   await server.register(graphqlProxy)
 
   // Start filesystem watchers
+  const { startWatchers } = await import('./util/fsWatching.js')
   await startWatchers()
 
   // Start connection watchers
+  const { startConnectionWatching } = await import(
+    './util/connectionWatching.js'
+  )
   startConnectionWatching()
 
   // Start the mail server
+  const { handleMail } = await import('./util/mail.js')
   const smtpServer = new SMTPServer({
     banner: 'RedwoodJS Studio SMTP Server',
     authOptional: true,

--- a/tasks/package.mjs
+++ b/tasks/package.mjs
@@ -153,9 +153,14 @@ async function main() {
   if (!verbose) {
     spinner.start('Copying over db files...')
   }
+  fs.mkdirSync(path.join(packagedDir, 'api', 'db'), { recursive: true })
   fs.copySync(
-    path.join(studioPath, 'api', 'db'),
-    path.join(packagedDir, 'api', 'db')
+    path.join(studioPath, 'api', 'db', 'schema.prisma'),
+    path.join(packagedDir, 'api', 'db', 'schema.prisma')
+  )
+  fs.copySync(
+    path.join(studioPath, 'api', 'db', 'migrations'),
+    path.join(packagedDir, 'api', 'db', 'migrations')
   )
   if (!verbose) {
     spinner.succeed('DB files copied!')


### PR DESCRIPTION
**Problem**
We generate the prisma client as part of redwood build - as is standard for redwood projects. However, we then ship this in the dist to end users. The prisma client is platform/architecture specific. This means, as an example, that the prisma client built for my M2 MacBook is not working for users that are running on amd64 ubuntu. 

**Changes**
1. We only copy over the schema and the migrations during our `studio:package` step.
2. We generate the prisma client when studio starts, similar to how we migrate and seed when studio starts

**Notes**
You might consider this wasteful from a performance point of view. The client likely only needs to be generated once for the user as the underlying platform/arch isn't likely to change. For now, I think this is acceptable and can be made more performant in a future chore - this is intended to fix the bug that users are experiencing right now.

The server file had to be updated to make use of dynamic imports in place of static imports. This is because the prisma client does not exist when the server file is loaded - only after a certain point in the execution of the server file does the client get generated. As a result static imports and any level of nested static imports of the prisma client will throw an error. Dynamically importing the functions that access the DB in this one file seems like an okay compromise. 