### PR TITLE
feat: Improve Connection Watcher performance for Dev Server Connection Status

### DIFF
--- a/api/src/util/connectionWatching.ts
+++ b/api/src/util/connectionWatching.ts
@@ -2,28 +2,39 @@ import { liveQueryStore } from '@redwoodjs/realtime'
 
 import { db } from 'src/lib/db'
 
-const STATUS_CHECK_INTERVAL_MS = 2000
+import { getUserProjectConfig } from './project'
+
+const STATUS_CHECK_INTERVAL_MS = 17_000
 let statusInterval: NodeJS.Timeout | null = null
 
 export function startConnectionWatching() {
+  const webConfig = getUserProjectConfig().web
+  const webHost = webConfig.host ?? 'localhost'
+  const graphqlEndpoint =
+    webConfig.apiGraphQLUrl ??
+    `http://${webHost}:${webConfig.port}${webConfig.apiUrl}/graphql`
+
   if (statusInterval) {
     stopConnectionWatching()
   }
 
   statusInterval = setInterval(async () => {
-    // Ping the web server to see if it's running
-    let webRespondedOk = false
+    // Ping the user project's graphQL health check endpoint
+    // to see if it's running
+    let isConnected = false
     try {
-      webRespondedOk = (await fetch('http://localhost:8910/')).ok
+      isConnected = (await fetch(`${graphqlEndpoint}/health`)).ok
     } catch (_error) {
-      //
+      // If the web server is not running, the fetch will throw an error
+      // but eat the error and webRespondedOk will be false
+      console.warn('🚨 Development Server not connected.')
     }
 
     // Upsert with a hard-coded ID of 1 as we only ever want the one row
     await db.connectionStatus.upsert({
       where: { id: 1 },
-      create: { id: 1, developmentServer: webRespondedOk },
-      update: { developmentServer: webRespondedOk },
+      create: { id: 1, developmentServer: isConnected },
+      update: { developmentServer: isConnected },
     })
 
     // Invalidate the live query

--- a/api/src/util/graphqlProxy.ts
+++ b/api/src/util/graphqlProxy.ts
@@ -1,11 +1,7 @@
 import httpProxy from '@fastify/http-proxy'
 import type { FastifyInstance, HookHandlerDoneFunction } from 'fastify'
 
-import {
-  getUserProjectWebHost,
-  getUserProjectWebPort,
-  getUserProjectGraphQlEndpoint,
-} from './project'
+import { getUserProjectConfig } from './project'
 
 /**
  * Graphql Proxy - Takes studio "/proxies/graphql" and forwards to the projects
@@ -26,7 +22,7 @@ export async function graphqlProxy(
     upstream: `http://${webHost}:${webConfig.port}`,
     prefix: '/proxies/graphql',
     // Strip the initial scheme://host:port from the graphqlEndpoint
-    rewritePrefix,
+    rewritePrefix: '/' + graphqlEndpoint.split('/').slice(3).join('/'),
     disableCache: true,
   })
 


### PR DESCRIPTION
This PR reworks the connection watcher to use GraphQL Health Check.

Why?

Currently, the watcher made a request to root localhost. And it did this every 2 seconds. Since the "home page" of an app would/could make a graphql and database request, this put an unnecessary amount of load on Studio -- and also created traces for request a user really did not make.  Thus the dashboard and sats did not represent actual usage.

This PR improves the watcher by:

1. Changing interval from 2 to 17 seconds. Why 17. about 3 per minute and prime number so doesn't hit as some clock time all the time :) Note: the could be configurable in future via env or other.
2. Using the GraphQL Healthcheck. This makes a http request to Yoga and will response ok or not. 
![image](https://github.com/redwoodjs/studio/assets/1051633/017f934c-9c66-47f6-9b4e-467b48de1a18)
 Note: This will add network request data to dashboard.
For example:
![image](https://github.com/redwoodjs/studio/assets/1051633/fdfb6295-b21e-4b85-99a8-a86218886d92)
6. Warning if connection is lost
7. Uses project config to get the graphql endpoint to make request vs hardcoded localhost and port
8. Fixes graphql proxy because of a mistake made in the merge of a PR that broke main