### PR TITLE
fix: process spans in the background

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -12,6 +12,7 @@ import { coerceRootPath, redwoodFastifyWeb } from '@redwoodjs/fastify-web'
 
 import { logger } from 'src/lib/logger'
 
+import { startSpanProcessor } from './functions/otel-trace/otel-trace'
 import { startConnectionWatching } from './util/connectionWatching'
 import { startWatchers } from './util/fsWatching'
 import { graphqlProxy } from './util/graphqlProxy'
@@ -105,6 +106,9 @@ export async function serve(
 
   // Start connection watchers
   startConnectionWatching()
+
+  // Start span processor
+  await startSpanProcessor()
 
   // Start the mail server
   const smtpServer = new SMTPServer({


### PR DESCRIPTION
**Problem**
We currently process spans directly when we handle the network request that is sent to them. The problem that arises is when this takes too much time and the sender - a redwood app - starts failing the export of the spans to the studio.

This has happened as a result of both sending many spans at the same time. This is made worse by the fact that span processing is not currently written with performance in mind. This is compounded again by the fact we use a SimpleSpanProcessor by default in a redwood app - which sends each span as it is ended.

**Changes**
We add raw span data to an array when we get the network requests and reply to the request without additional work. We then process these in spans in batches via an interval - currently at one second.