### PR TITLE
fix(otel): Support OTel timestamp which is simple string

### DIFF
--- a/api/src/functions/otel-trace/otel-trace.ts
+++ b/api/src/functions/otel-trace/otel-trace.ts
@@ -29,15 +29,16 @@ function getMD5Hash(value: unknown) {
 }
 
 // TODO: Move this somewhere more appropriate
-function convertLongToBigInt({
-  low,
-  high,
-  unsigned,
-}: {
+type Long = {
   low: number
   high: number
   unsigned?: boolean
-}) {
+}
+function convertLongToBigInt(input: Long | string) {
+  if (typeof input === 'string') {
+    return BigInt(input)
+  }
+  const { low, high, unsigned } = input
   const lowBI = BigInt.asUintN(32, BigInt(low))
   const highBI = BigInt.asUintN(32, BigInt(high))
   const combined = (highBI << 32n) | lowBI


### PR DESCRIPTION
**Problem**
It appears that in some situations the timestamps received during OTel ingestion as strings rather than objects that contain details of the corresponding unix nanosecond timestamp.

See: https://community.redwoodjs.com/t/opentelemetry-support-experimental/4772/17

**Changes**
1. When we receive a string just process that rather than go through the object handling logic. 