### PR TITLE
fix: Lazy import the span processor in server to process spans

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -12,9 +12,6 @@ import { coerceRootPath, redwoodFastifyWeb } from '@redwoodjs/fastify-web'
 
 import { logger } from 'src/lib/logger'
 
-import { startSpanProcessor } from './functions/otel-trace/otel-trace'
-import { startConnectionWatching } from './util/connectionWatching'
-import { startWatchers } from './util/fsWatching'
 import { graphqlProxy } from './util/graphqlProxy'
 import {
   getStudioConfig,
@@ -115,8 +112,12 @@ export async function serve(
   )
   startConnectionWatching()
 
-  // Start span processor
-  await startSpanProcessor()
+  // Start span processing
+  const { startSpanProcessor } = await import(
+    './functions/otel-trace/otel-trace.js'
+  )
+
+  startSpanProcessor()
 
   // Start the mail server
   const { handleMail } = await import('./util/mail.js')


### PR DESCRIPTION
With https://github.com/redwoodjs/studio/pull/44 now generating the Prisma Client, anything that relies on `db` in server needs to be lazy imported -- otherwise it cannot find the client.

This PR lazy loads the span processor.