### PR TITLE
fix(rsc): Correct icon for Render Routes

### DIFF
--- a/web/src/layouts/SidebarLayout/navigationStructure.ts
+++ b/web/src/layouts/SidebarLayout/navigationStructure.ts
@@ -13,6 +13,7 @@ import {
   OGTagPreviewIcon,
   OperationsIcon,
   PlaygroundIcon,
+  RoutesIcon,
   SpansIcon,
   SqlStatementsIcon,
   TemplatesIcon,
@@ -114,7 +115,7 @@ export function useNavigationStructure(routes: AvailableRoutes) {
     {
       name: 'Render Routes',
       to: routes.renderGraphRoutes(),
-      icon: FlightIcon,
+      icon: RoutesIcon,
     },
   ]
 


### PR DESCRIPTION
Forgot to update what icon is used when I copy/pasted an existing nav menu entry